### PR TITLE
[BUGFIX] Pin runit cookbook to <4.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ version          IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0
 depends          "chef-client", "= 4.3.3"
 depends          "chef_handler"
 depends          "omnibus_updater", "= 1.1.0"
-depends          "runit"
+depends          "runit", "< 4.0"


### PR DESCRIPTION
Version 4.0 fails on older Debian versions with
>   * service[runit] action start
>    * /etc/init.d/runit does not exist!